### PR TITLE
handling of mail binary in a more generic way

### DIFF
--- a/mongosback.sh
+++ b/mongosback.sh
@@ -6,8 +6,17 @@
 
 set -o errtrace
 
+while getopts f: OPT
+do
+	case $OPT in
+		f) CONFIG="$OPTARG"
+	esac
+done
+
 if [ -f "mongosback.conf" ] ; then
   . ./mongosback.conf
+elif [ ! -z "$CONFIG" ]; then
+  . $CONFIG
 else
   logger -s "mongosback unable to read the configuration file, exiting prematurely"
   exit 1


### PR DESCRIPTION
I had an issue on ubuntu 12.04 with exim installed where the mail binary is located in /usr/bin/ - so I made a minor change for executing mail

I added the option '-f <config file>' because we usually seperate binaries/scripts from config files.
